### PR TITLE
Install pkgdown with BiocManager

### DIFF
--- a/.github/workflows/check-bioc-cran.yml
+++ b/.github/workflows/check-bioc-cran.yml
@@ -186,7 +186,9 @@ jobs:
       - name: Install pkgdown
         if: github.ref == 'refs/heads/master' && env.run_pkgdown == 'true'
         run: |
-          remotes::install_github("r-lib/pkgdown")
+          ## Install with BiocManager instead of remotes to get a version 
+          ## that works with the Bioc release
+          BiocManager::install("pkgdown")
         shell: Rscript {0}
   
       - name: Install package


### PR DESCRIPTION
This should fix the fail. It's due to the actions trying to install pkgdown from Github that has a downlit dependency that's not available for the Bioc Docker release 3.11. Installing pkgdown with BiocManager fixes it.