### PR TITLE
Update README & GHA

### DIFF
--- a/.github/workflows/check-bioc-cran.yml
+++ b/.github/workflows/check-bioc-cran.yml
@@ -1,10 +1,9 @@
 ## Maria: This GHA is adapted from lcolladotor's one described below.
+## - Autodetects current Bioc release and tests against that Docker image for ubuntu. 
+##   Tests against current Bioc release packages and R version for Mac and Windows
 ## - Changed - to _ in variable names to try to use act (https://github.com/nektos/act) 
-##   for testing GHA locally
-## - Removed the needs: due to this with act https://github.com/nektos/act/issues/295
-## - Had to hardcode bioconductor version in a few places below for moment as couldn't use env variable
-## - Some Bioconductor packages failed to install locally with act, might be due 
-##   to the issue lcolladotor mentions below
+##   for testing GHA locally. But added back needs: so won't work with act but can test with my fork
+## 
 ##
 ## Read more about GitHub actions the features of this GitHub Actions workflow
 ## at https://lcolladotor.github.io/biocthis/articles/biocthis.html#use_bioc_github_action
@@ -55,19 +54,59 @@ name: R_CMD_check_bioc
 ## Note that you can always run a GHA test without the cache by using the word
 ## "/nocache" in the commit message.
 env:
-  rversion: '4.0'
-  biocversionnum: '3_11'
-  biocversion: 'RELEASE_3_11'
   has_testthat: 'true'
   run_covr: 'true'
   run_pkgdown: 'true'
   cache_version: 'cache_v1'
 
 jobs:
+  ## The first job uses the Bioconductor devel Docker to get the R and Bioconductor version numbers for the current Bioc release
+  ## There may be a better way to do this without using Bioc devel docker
+  define_bioc_version:
+    runs-on: ubuntu-latest
+    
+    outputs:
+      rversion: ${{ steps.findversion.outputs.rversion }}
+      biocversionnum: ${{ steps.findversion.outputs.biocversionnum }}
+      imagename: ${{ steps.findversion.outputs.imagename }}
+      
+    container:
+      image: "bioconductor/bioconductor_docker:devel"
+      
+    steps:
+      - name: Install BiocManager
+        run: |
+          install.packages('remotes')
+          message(paste('****', Sys.time(), 'installing BiocManager ****'))
+          remotes::install_cran("BiocManager")
+        shell: Rscript {0}
+        
+      - id: findversion
+        name: Find Bioc and R versions
+        run: |
+          ## Define the R and Bioconductor version numbers for the current Bioc release
+          biocversionnum=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == 'release')[, 'Bioc']; cat(as.character(res))")
+          biocrelease=${biocversionnum/\./_}
+          biocrelease=${biocrelease/#/RELEASE_}
+          imagename="bioconductor/bioconductor_docker:${biocrelease}"
+          rversion=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == 'release')[, 'R']; cat(as.character(res))")
+         
+          ## Print the results
+          echo $rversion
+          echo $biocversionnum
+          echo $imagename
+
+          ## Save the info for the next job
+          echo "::set-output name=rversion::${rversion}"
+          echo "::set-output name=biocversionnum::${biocversionnum}"
+          echo "::set-output name=imagename::${imagename}"
+        shell: bash {0}
   R_CMD_check_bioc:
     runs-on: ubuntu-latest
+    needs: define_bioc_version
+    
     ## Name shown on the GHA log
-    name: ubuntu-latest (r_biocdocker)
+    name: (r-biocdocker bioc-${{ needs.define_bioc_version.outputs.biocversionnum }})
     ## Environment variables unique to this job.
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -79,7 +118,7 @@ jobs:
       ## runner to a docker directory, such that we can then cache the linked
       ## directory. This directory will contain the R packages used.
     container:
-      image: bioconductor/bioconductor_docker:RELEASE_3_11
+      image: ${{ needs.define_bioc_version.outputs.imagename }}
       volumes:
       - /home/runner/work/_temp/Library:/usr/local/lib/R/host-site-library
     steps:
@@ -120,8 +159,8 @@ jobs:
         uses: actions/cache@v1
         with:
          path: /home/runner/work/_temp/Library
-         key: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}_bioc_${{ env.biocversionnum }}_${{ hashFiles('.github/depends.Rds') }}
-         restore-keys: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}_bioc_${{ env.biocversionnum }}-
+         key: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}_bioc_${{ needs.define_bioc_version.outputs.biocversionnum }}_${{ hashFiles('.github/depends.Rds') }}
+         restore-keys: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}_bioc_${{ needs.define_bioc_version.outputs.biocversionnum }}_
       
       - name: Install dependencies
         run: |
@@ -211,7 +250,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@master
         with:
-          name: ${{ runner.os }}_biocdocker_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}_bioc_${{ env.biocversionnum }}_results
+          name: ${{ runner.os }}_biocdocker_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}_bioc_${{ needs.define_bioc_version.outputs.biocversionnum }}_results
           path: check
       
         ## Run R CMD check on both macOS and Windows. You can also run the
@@ -222,6 +261,7 @@ jobs:
         ## dependencies as well, thus making this workflow useful beyond Bioconductor)
   R_CMD_check_r_lib:
     runs-on: ${{ matrix.config.os }}
+    needs: define_bioc_version
     
     name: ${{ matrix.config.os }}
     
@@ -237,7 +277,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
-      BIOCVERSIONNUM: '3.11'
+      BIOCVERSIONNUM: ${{ needs.define_bioc_version.outputs.biocversionnum }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     
     steps:
@@ -246,7 +286,7 @@ jobs:
       - name: Setup R from r-lib
         uses: r-lib/actions/setup-r@master
         with:
-          r-version: ${{ env.rversion }}
+          r-version: ${{ needs.define_bioc_version.outputs.rversion }}
     
       - name: Setup pandoc from r-lib
         uses: r-lib/actions/setup-pandoc@master
@@ -262,9 +302,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ env.cache_version }}_${{ runner.os }}_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}_bioc_${{ env.biocversion }}_${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ env.cache_version }}_${{ runner.os }}_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}_bioc_${{ env.biocversion }}-
-          
+          key: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}_bioc_${{ needs.define_bioc_version.outputs.biocversionnum }}_${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ env.cache_version }}_${{ runner.os }}_biocdocker_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}_bioc_${{ needs.define_bioc_version.outputs.biocversionnum }}_
+      
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         env:
@@ -354,5 +394,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@master
         with:
-          name: ${{ runner.os }}_biocbranch_${{ env.biocversion }}_r_${{ env.rversion }}-bioc_${{ env.biocversion }}_results
+          name: ${{ runner.os }}_biocbranch_${{ needs.define_bioc_version.outputs.biocversion }}_r_${{ needs.define_bioc_version.outputs.rversion }}-bioc_${{ needs.define_bioc_version.outputs.biocversion }}_results
           path: check 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ From Github (development)
     library(magrittr)
     library(ggplot2)
     library(Seurat)
-    library(SingleCellSignalR)
     library(tidyseurat)
 
 Create `tidyseurat`, the best of both worlds!
@@ -165,7 +164,12 @@ Preliminary plots
 Set colours and theme for plots.
 
     # Use colourblind-friendly colours
-    friendly_cols <- dittoSeq::dittoColors()
+    if (requireNamespace("dittoSeq", quietly = TRUE)) {
+          friendly_cols <- dittoSeq::dittoColors()
+       } else {
+          friendly_cols <- c("red", "blue", "green", "purple")
+       }
+
     # Set theme
     my_theme <-
       list(
@@ -532,6 +536,8 @@ with this small example dataset as we have just two samples (one for
 each condition). But some example output is shown below and you can
 imagine how you can use tidyverse on the output to perform t-tests and
 visualisation.
+
+    library(SingleCellSignalR)
 
     pbmc_small_nested_interactions <-
       pbmc_small_nested_reanalysed %>%


### PR DESCRIPTION
Noticed the vignette was updated but the README wasn't so updated it here. You still have to do a Knit of the README.Rmd to update the README.md if you change the man/fragment/intro.Rmd.

By the way what do you think now that it's incorporated,, is the man/fragements shared content vignette/README ok for you?

Also modified the GHA to autodetect the current Bioc release to test against instead of hardcoding the version. So it tests against 3.11 now & will autodetect Bioc 3.12 when it's released next month.