### PR TITLE
Change `pivot_longer()` argument defaults from `list()` to `NULL`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     tibble,
     dplyr,
     magrittr,
-    tidyr,
+    tidyr (>= 1.2.0),
     ggplot2,
     rlang,
     purrr,

--- a/R/tidyr_methods.R
+++ b/R/tidyr_methods.R
@@ -337,13 +337,13 @@ pivot_longer.Seurat <- function(data,
                                   names_prefix = NULL,
                                   names_sep = NULL,
                                   names_pattern = NULL,
-                                  names_ptypes = list(),
-                                  names_transform = list(),
+                                  names_ptypes = NULL,
+                                  names_transform = NULL,
                                   names_repair = "check_unique",
                                   values_to = "value",
                                   values_drop_na = FALSE,
-                                  values_ptypes = list(),
-                                  values_transform = list(),
+                                  values_ptypes = NULL,
+                                  values_transform = NULL,
                                   ...
 ) {
   cols <- enquo(cols) 


### PR DESCRIPTION
In tidyr 1.2.0 we updated `pivot_longer()`'s `names_transform`, `values_transform`, `names_ptypes` and `values_ptypes` arguments to allow a _single_ function or ptype which will be applied to all columns, rather than requiring a named list. See https://github.com/tidyverse/tidyr/blob/main/NEWS.md#pivoting

This required us to change the default argument from `list()` to `NULL`. In particular, for `names/values_ptypes`, this was important because `list()` should now be interpreted as "use a list ptype for all columns".

For backwards compatibility with tidyseurat and a few other packages that extend `pivot_longer()`, we have temporarily forced `list()` to be interpreted as `NULL`, but we would like to remove this behavior. See https://github.com/tidyverse/tidyr/issues/1296.

This PR is a step towards that by updating the signature used in tidyseurat to use `NULL` rather than `list()`. We would appreciate if you could merge this in and get it on CRAN at your earliest convenience!