### PR TITLE
Increase unit test coverage

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -62,7 +62,7 @@ drop_class = function(var, name) {
   var
 }
 
-#' get abundance long
+#' get abundance wide
 #'
 #' @keywords internal
 #'
@@ -77,9 +77,7 @@ drop_class = function(var, name) {
 #' @param all A boolean
 #' @param ... Parameters to pass to join wide, i.e. assay name to extract feature abundance from
 #'
-#'
 #' @return A Seurat object
-#'
 #'
 #' @export
 get_abundance_sc_wide = function(.data, features = NULL, all = FALSE, assay = .data@active.assay, slot = "data", prefix = ""){

--- a/man/get_abundance_sc_wide.Rd
+++ b/man/get_abundance_sc_wide.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utilities.R
 \name{get_abundance_sc_wide}
 \alias{get_abundance_sc_wide}
-\title{get abundance long}
+\title{get abundance wide}
 \usage{
 get_abundance_sc_wide(
   .data,
@@ -26,6 +26,6 @@ get_abundance_sc_wide(
 A Seurat object
 }
 \description{
-get abundance long
+get abundance wide
 }
 \keyword{internal}

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -122,3 +122,15 @@ test_that("count", {
     expect_equal(230)
 })
 
+test_that("rowwise", {
+  cell_rowwise_mean <-
+    pbmc_small |>  
+    rowwise() |>
+    mutate(m = mean(c(nCount_RNA, nFeature_RNA))) |>
+    purrr::pluck("m", 1)
+  cell_manual_mean <-
+    ((pbmc_small[, 1]$nCount_RNA + pbmc_small[, 1]$nFeature_RNA) / 2) |>
+    unname()
+  expect_equal(cell_rowwise_mean, cell_manual_mean)
+})
+

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -6,8 +6,8 @@ set.seed(42)
 
 test_that("arrange",{
 
-  pbmc_small_pca_arranged = pbmc_small %>% arrange(nFeature_RNA) %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
-  pbmc_small_pca = pbmc_small %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
+  pbmc_small_pca_arranged = pbmc_small |> arrange(nFeature_RNA) |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
+  pbmc_small_pca = pbmc_small |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
 
   expect_equal(
     Seurat::VariableFeatures(pbmc_small_pca_arranged),
@@ -33,7 +33,7 @@ test_that("bind_rows",{
 
 
   expect_equal(
-    pbmc_small_bind %>% select(cell) %>% as_tibble() %>% dplyr::count(cell) %>% dplyr::count(n) %>% nrow,
+    pbmc_small_bind |> select(cell) |> as_tibble() |> dplyr::count(cell) |> dplyr::count(n) |> nrow(),
     1
   )
 
@@ -43,96 +43,96 @@ test_that("bind_rows",{
 
 test_that("bind_cols",{
 
-  pbmc_small_bind = pbmc_small %>% select(nCount_RNA ,nFeature_RNA)
+  pbmc_small_bind = pbmc_small |> select(nCount_RNA ,nFeature_RNA)
 
-  pbmc_small %>%
-    bind_cols(pbmc_small_bind) %>%
-    select(nCount_RNA...2 ,nFeature_RNA...3) %>%
-    ncol %>%
+  pbmc_small |>
+    bind_cols(pbmc_small_bind) |>
+    select(nCount_RNA...2 ,nFeature_RNA...3) |>
+    ncol() |>
   expect_equal( 2)
 
 })
 
 test_that("distinct",{
 
-  expect_equal(   pbmc_small %>% distinct(groups) |> ncol(),    1  )
+  expect_equal(   pbmc_small |> distinct(groups) |> ncol(),    1  )
 
 })
 
 test_that("filter",{
 
-  expect_equal(   pbmc_small %>% filter(groups == "g1") |> ncol(),    44  )
+  expect_equal(   pbmc_small |> filter(groups == "g1") |> ncol(),    44  )
 
 })
 
 test_that("group_by",{
 
-  expect_equal(   pbmc_small %>% group_by(groups) %>% nrow,    80  )
+  expect_equal(   pbmc_small |> group_by(groups) |> nrow(),    80  )
 
 })
 
 test_that("summarise",{
 
-  expect_equal(   pbmc_small %>% summarise(mean(nCount_RNA)) %>% nrow,    1  )
+  expect_equal(   pbmc_small |> summarise(mean(nCount_RNA)) |> nrow(),    1  )
 
 })
 
 test_that("mutate",{
 
-  expect_equal(   pbmc_small %>% mutate(nFeature_RNA = 1) %>% distinct(nFeature_RNA) %>% nrow,    1  )
+  expect_equal(   pbmc_small |> mutate(nFeature_RNA = 1) |> distinct(nFeature_RNA) |> nrow(),    1  )
 
 })
 
 test_that("rename",{
 
-  expect_equal(   pbmc_small %>% rename(s_score = nFeature_RNA) %>% select(s_score) |> ncol(),    1  )
+  expect_equal(   pbmc_small |> rename(s_score = nFeature_RNA) |> select(s_score) |> ncol(),    1  )
 
 })
 
 test_that("left_join",{
 
-  pbmc_small %>% left_join(pbmc_small %>% distinct(groups) %>% mutate(new_column = 1:2)) %>% `@` (meta.data) |> ncol() %>%
-  expect_equal( 8  )
+  pbmc_small |> left_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol() |>
+  expect_equal( 80  )
 
 })
 
 test_that("inner_join",{
 
-  expect_equal(   pbmc_small %>% inner_join(pbmc_small %>% distinct(groups) %>% mutate(new_column = 1:2) %>% slice(1)) |> ncol(),    36  )
+  expect_equal(   pbmc_small |> inner_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),    36  )
 
 })
 
 test_that("right_join",{
 
-  expect_equal(   pbmc_small %>% right_join(pbmc_small %>% distinct(groups) %>% mutate(new_column = 1:2) %>% slice(1)) |> ncol(),    36  )
+  expect_equal(   pbmc_small |> right_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),    36  )
 
 })
 
 test_that("full_join",{
 
-  expect_equal(   pbmc_small %>% full_join(tibble::tibble(groups = "g1", other=1:4)) %>% nrow,    212  )
+  expect_equal(   pbmc_small |> full_join(tibble::tibble(groups = "g1", other=1:4)) |> nrow(),    212  )
 
 })
 
 test_that("slice",{
 
-  expect_equal(   pbmc_small %>% slice(1) |> ncol(),    1  )
+  expect_equal(   pbmc_small |> slice(1) |> ncol(),    1  )
 
 })
 
 test_that("select",{
 
-  expect_equal(   pbmc_small %>% select(cell, orig.ident ) %>% class %>% as.character,    "Seurat"  )
+  expect_equal(   pbmc_small |> select(cell, orig.ident ) |> class() |> as.character(),    "Seurat"  )
 
-  expect_equal(   pbmc_small %>% select( orig.ident ) %>% class %>% as.character %>% .[1],    "tbl_df"  )
+  expect_equal(   pbmc_small |> select( orig.ident ) |> class() |> as.character() |> purrr::pluck(1),    "tbl_df"  )
 
 })
 
 test_that("sample_n",{
 
-  expect_equal(   pbmc_small %>% sample_n(50) |> ncol(),   50  )
+  expect_equal(   pbmc_small |> sample_n(50) |> ncol(),   50  )
 
-  expect_equal(   pbmc_small %>% sample_n(500, replace = TRUE) |> ncol(),   29  )
+  expect_equal(   pbmc_small |> sample_n(500, replace = TRUE) |> ncol(),   29  )
 
 })
 
@@ -148,9 +148,9 @@ test_that("slice_sample",{
 
 test_that("sample_frac",{
 
-  expect_equal(   pbmc_small %>% sample_frac(0.1) |> ncol(),   8  )
+  expect_equal(   pbmc_small |> sample_frac(0.1) |> ncol(),   8  )
 
-  expect_equal(   pbmc_small %>% sample_frac(10, replace = TRUE) |> ncol(),   29  )
+  expect_equal(   pbmc_small |> sample_frac(10, replace = TRUE) |> ncol(),   29  )
   
 })
 
@@ -173,3 +173,4 @@ test_that("count",{
   
   
 })
+

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -16,18 +16,9 @@ test_that("arrange", {
     pbmc_small_pca[["pca"]]@cell.embeddings,
     tolerance=0.1
   )
-  pbmc_small_pca_arranged |> 
-    as_tibble() |>
-    dplyr::slice_head(n = 1) |>
-    dplyr::pull(nFeature_RNA) |>
-    expect_equal(26)
-})
-
-test_that("bind_rows", {
-  pbmc_small_bind <- bind_rows(pbmc_small, pbmc_small)
   expect_equal(
-    pbmc_small_bind |> select(cell) |> as_tibble() |> dplyr::count(cell) |> dplyr::count(n) |> nrow(),
-    1
+    pbmc_small_pca_arranged |> as_tibble() |>dplyr::slice_head(n = 1),
+    pbmc_small_pca |> as_tibble() |> dplyr::slice_min(nFeature_RNA, n = 1)
   )
 })
 
@@ -37,7 +28,7 @@ test_that("bind_cols", {
     bind_cols(pbmc_small_bind) |>
     select(nCount_RNA...2, nFeature_RNA...3) |>
     ncol() |>
-    expect_equal( 2)
+    expect_equal(2)
 })
 
 test_that("distinct", {
@@ -45,11 +36,17 @@ test_that("distinct", {
 })
 
 test_that("filter", {
-  expect_equal(pbmc_small |> filter(groups == "g1") |> ncol(), 44)
+  expect_equal(
+    pbmc_small |> filter(groups == "g1") |> ncol(),
+    sum(pbmc_small[[]]$groups == "g1")
+  )
 })
 
 test_that("group_by", {
-  expect_equal(pbmc_small |> group_by(groups) |> nrow(), 80)
+  expect_equal(
+    pbmc_small |> group_by(groups) |> nrow(),
+    nrow(pbmc_small[[]])
+  )
 })
 
 test_that("summarise", {
@@ -65,21 +62,31 @@ test_that("rename", {
 })
 
 test_that("left_join", {
-  pbmc_small |> left_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol() |>
-  expect_equal(80)
+  expect_equal(
+    pbmc_small |> left_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),
+    nrow(pbmc_small[[]])
+  )
 })
 
 test_that("inner_join", {
-  expect_equal(pbmc_small |> inner_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(), 36)
-
+  expect_equal(
+    pbmc_small |> inner_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),
+    sum(pbmc_small[[]]$groups == "g2")
+  )
 })
 
 test_that("right_join", {
-  expect_equal(pbmc_small |> right_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(), 36)
+    expect_equal(
+      pbmc_small |> right_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),
+      sum(pbmc_small[[]]$groups == "g2")
+  )
 })
 
 test_that("full_join", {
-  expect_equal(pbmc_small |> full_join(tibble::tibble(groups = "g1", other = 1:4)) |> nrow(), 212)
+  expect_equal(
+    pbmc_small |> full_join(tibble::tibble(groups = "g1", other = 1:4)) |> nrow(), 
+    sum(pbmc_small[[]]$groups == "g1") * 4 + sum(pbmc_small[[]]$groups == "g2")
+  )
 })
 
 test_that("slice", {
@@ -93,7 +100,10 @@ test_that("select", {
 
 test_that("sample_n", {
   expect_equal(pbmc_small |> sample_n(50) |> ncol(), 50)
-  expect_equal(pbmc_small |> sample_n(500, replace = TRUE) |> ncol(), 29)
+  expect_equal(
+    pbmc_small |> sample_n(500, replace = TRUE) |> ncol(),
+    pbmc_small |> as_tibble() |> ncol()
+  )
 })
 
 test_that("slice_sample", {
@@ -104,33 +114,33 @@ test_that("slice_sample", {
 })
 
 test_that("sample_frac", {
-  expect_equal(pbmc_small |> sample_frac(0.1) |> ncol(), 8)
-  expect_equal(pbmc_small |> sample_frac(10, replace = TRUE) |> ncol(), 29)
+  expect_equal(
+    pbmc_small |> sample_frac(0.1) |> ncol(),
+    nrow(pbmc_small[[]]) * 0.1
+  )
+  expect_equal(
+    pbmc_small |> sample_frac(10, replace = TRUE) |> ncol(),
+    pbmc_small |> as_tibble() |> ncol()
+  )
 })
 
 test_that("count", {
-  pbmc_small |>  
-    count(groups) |> 
-    nrow() |> 
-    expect_equal(2)
+  expect_equal(
+    pbmc_small |> count(groups) |> nrow(),
+    pbmc_small[[]]$groups |> unique() |> length()
+  )
 })
 
-test_that("count", {
-  pbmc_small |>  
-    add_count(groups) |> 
-    nrow() |> 
-    expect_equal(230)
+test_that("add_count", {
+  expect_equal(
+    pbmc_small |> add_count(groups) |> nrow(), 
+    pbmc_small |> rownames() |> length()
+  )
 })
 
 test_that("rowwise", {
-  cell_rowwise_mean <-
-    pbmc_small |>  
-    rowwise() |>
-    mutate(m = mean(c(nCount_RNA, nFeature_RNA))) |>
-    purrr::pluck("m", 1)
-  cell_manual_mean <-
-    ((pbmc_small[, 1]$nCount_RNA + pbmc_small[, 1]$nFeature_RNA) / 2) |>
-    unname()
-  expect_equal(cell_rowwise_mean, cell_manual_mean)
+  expect_equal(
+    pbmc_small |> rowwise() |> mutate(m = mean(c(nCount_RNA, nFeature_RNA))) |> purrr::pluck("m", 1),
+    ((pbmc_small[, 1]$nCount_RNA + pbmc_small[, 1]$nFeature_RNA) / 2) |> unname()
+  )
 })
-

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -4,25 +4,28 @@ library(Seurat)
 data("pbmc_small")
 set.seed(42)
 
-# test_that("arrange",{
-# 
-# 
-#   pbmc_small_pca_arranged = pbmc_small %>% arrange(nFeature_RNA) %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
-#   pbmc_small_pca = pbmc_small %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
-# 
-#   expect_equal(
-#     Seurat::VariableFeatures(pbmc_small_pca_arranged),
-#     Seurat::VariableFeatures(pbmc_small_pca)
-#   )
-# 
-#   expect_equal(
-#     pbmc_small_pca_arranged[["pca"]]@cell.embeddings ,
-#     pbmc_small_pca[["pca"]]@cell.embeddings,
-#     tolerance=0.1
-#   )
-# 
-# 
-# })
+test_that("arrange",{
+
+  pbmc_small_pca_arranged = pbmc_small %>% arrange(nFeature_RNA) %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
+  pbmc_small_pca = pbmc_small %>% Seurat::ScaleData() %>% Seurat::FindVariableFeatures() %>% Seurat::RunPCA()
+
+  expect_equal(
+    Seurat::VariableFeatures(pbmc_small_pca_arranged),
+    Seurat::VariableFeatures(pbmc_small_pca)
+  )
+
+  expect_equal(
+    pbmc_small_pca_arranged[["pca"]]@cell.embeddings ,
+    pbmc_small_pca[["pca"]]@cell.embeddings,
+    tolerance=0.1
+  )
+  
+  pbmc_small_pca_arranged |> 
+    as_tibble() |>
+    dplyr::slice_head(n = 1) |>
+    dplyr::pull(nFeature_RNA) |>
+    expect_equal(26)
+})
 
 test_that("bind_rows",{
 

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -4,22 +4,18 @@ library(Seurat)
 data("pbmc_small")
 set.seed(42)
 
-test_that("arrange",{
-
-  pbmc_small_pca_arranged = pbmc_small |> arrange(nFeature_RNA) |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
-  pbmc_small_pca = pbmc_small |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
-
+test_that("arrange", {
+  pbmc_small_pca_arranged <- pbmc_small |> arrange(nFeature_RNA) |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
+  pbmc_small_pca <- pbmc_small |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
   expect_equal(
     Seurat::VariableFeatures(pbmc_small_pca_arranged),
     Seurat::VariableFeatures(pbmc_small_pca)
   )
-
   expect_equal(
-    pbmc_small_pca_arranged[["pca"]]@cell.embeddings ,
+    pbmc_small_pca_arranged[["pca"]]@cell.embeddings,
     pbmc_small_pca[["pca"]]@cell.embeddings,
     tolerance=0.1
   )
-  
   pbmc_small_pca_arranged |> 
     as_tibble() |>
     dplyr::slice_head(n = 1) |>
@@ -27,150 +23,102 @@ test_that("arrange",{
     expect_equal(26)
 })
 
-test_that("bind_rows",{
-
-  pbmc_small_bind = bind_rows(    pbmc_small, pbmc_small  )
-
-
+test_that("bind_rows", {
+  pbmc_small_bind <- bind_rows(pbmc_small, pbmc_small)
   expect_equal(
     pbmc_small_bind |> select(cell) |> as_tibble() |> dplyr::count(cell) |> dplyr::count(n) |> nrow(),
     1
   )
-
-
-
 })
 
-test_that("bind_cols",{
-
-  pbmc_small_bind = pbmc_small |> select(nCount_RNA ,nFeature_RNA)
-
+test_that("bind_cols", {
+  pbmc_small_bind <- pbmc_small |> select(nCount_RNA, nFeature_RNA)
   pbmc_small |>
     bind_cols(pbmc_small_bind) |>
-    select(nCount_RNA...2 ,nFeature_RNA...3) |>
+    select(nCount_RNA...2, nFeature_RNA...3) |>
     ncol() |>
-  expect_equal( 2)
-
+    expect_equal( 2)
 })
 
-test_that("distinct",{
-
-  expect_equal(   pbmc_small |> distinct(groups) |> ncol(),    1  )
-
+test_that("distinct", {
+  expect_equal(pbmc_small |> distinct(groups) |> ncol(), 1)
 })
 
-test_that("filter",{
-
-  expect_equal(   pbmc_small |> filter(groups == "g1") |> ncol(),    44  )
-
+test_that("filter", {
+  expect_equal(pbmc_small |> filter(groups == "g1") |> ncol(), 44)
 })
 
-test_that("group_by",{
-
-  expect_equal(   pbmc_small |> group_by(groups) |> nrow(),    80  )
-
+test_that("group_by", {
+  expect_equal(pbmc_small |> group_by(groups) |> nrow(), 80)
 })
 
-test_that("summarise",{
-
-  expect_equal(   pbmc_small |> summarise(mean(nCount_RNA)) |> nrow(),    1  )
-
+test_that("summarise", {
+  expect_equal(pbmc_small |> summarise(mean(nCount_RNA)) |> nrow(), 1)
 })
 
-test_that("mutate",{
-
-  expect_equal(   pbmc_small |> mutate(nFeature_RNA = 1) |> distinct(nFeature_RNA) |> nrow(),    1  )
-
+test_that("mutate", {
+  expect_equal(pbmc_small |> mutate(nFeature_RNA = 1) |> distinct(nFeature_RNA) |> nrow(), 1)
 })
 
-test_that("rename",{
-
-  expect_equal(   pbmc_small |> rename(s_score = nFeature_RNA) |> select(s_score) |> ncol(),    1  )
-
+test_that("rename", {
+  expect_equal(pbmc_small |> rename(s_score = nFeature_RNA) |> select(s_score) |> ncol(), 1)
 })
 
-test_that("left_join",{
-
+test_that("left_join", {
   pbmc_small |> left_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol() |>
-  expect_equal( 80  )
+  expect_equal(80)
+})
+
+test_that("inner_join", {
+  expect_equal(pbmc_small |> inner_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(), 36)
 
 })
 
-test_that("inner_join",{
-
-  expect_equal(   pbmc_small |> inner_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),    36  )
-
+test_that("right_join", {
+  expect_equal(pbmc_small |> right_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(), 36)
 })
 
-test_that("right_join",{
-
-  expect_equal(   pbmc_small |> right_join(pbmc_small |> distinct(groups) |> mutate(new_column = 1:2) |> slice(1)) |> ncol(),    36  )
-
+test_that("full_join", {
+  expect_equal(pbmc_small |> full_join(tibble::tibble(groups = "g1", other = 1:4)) |> nrow(), 212)
 })
 
-test_that("full_join",{
-
-  expect_equal(   pbmc_small |> full_join(tibble::tibble(groups = "g1", other=1:4)) |> nrow(),    212  )
-
+test_that("slice", {
+  expect_equal(pbmc_small |> slice(1) |> ncol(), 1)
 })
 
-test_that("slice",{
-
-  expect_equal(   pbmc_small |> slice(1) |> ncol(),    1  )
-
+test_that("select", {
+  expect_equal(pbmc_small |> select(cell, orig.ident) |> class() |> as.character(), "Seurat")
+  expect_equal(pbmc_small |> select(orig.ident) |> class() |> as.character() |> purrr::pluck(1), "tbl_df")
 })
 
-test_that("select",{
-
-  expect_equal(   pbmc_small |> select(cell, orig.ident ) |> class() |> as.character(),    "Seurat"  )
-
-  expect_equal(   pbmc_small |> select( orig.ident ) |> class() |> as.character() |> purrr::pluck(1),    "tbl_df"  )
-
+test_that("sample_n", {
+  expect_equal(pbmc_small |> sample_n(50) |> ncol(), 50)
+  expect_equal(pbmc_small |> sample_n(500, replace = TRUE) |> ncol(), 29)
 })
 
-test_that("sample_n",{
-
-  expect_equal(   pbmc_small |> sample_n(50) |> ncol(),   50  )
-
-  expect_equal(   pbmc_small |> sample_n(500, replace = TRUE) |> ncol(),   29  )
-
-})
-
-test_that("slice_sample",{
-  
+test_that("slice_sample", {
   pbmc_small |> 
-    slice_sample(n=50) |> 
+    slice_sample(n = 50) |> 
     ncol() |>
-    expect_equal( 50 )
-  
-
+    expect_equal(50)
 })
 
-test_that("sample_frac",{
-
-  expect_equal(   pbmc_small |> sample_frac(0.1) |> ncol(),   8  )
-
-  expect_equal(   pbmc_small |> sample_frac(10, replace = TRUE) |> ncol(),   29  )
-  
+test_that("sample_frac", {
+  expect_equal(pbmc_small |> sample_frac(0.1) |> ncol(), 8)
+  expect_equal(pbmc_small |> sample_frac(10, replace = TRUE) |> ncol(), 29)
 })
 
-test_that("count",{
-
+test_that("count", {
   pbmc_small |>  
     count(groups) |> 
     nrow() |> 
-  expect_equal(     2  )
-
-
+    expect_equal(2)
 })
 
-test_that("count",{
-  
+test_that("count", {
   pbmc_small |>  
     add_count(groups) |> 
     nrow() |> 
-    expect_equal(     230  )
-  
-  
+    expect_equal(230)
 })
 

--- a/tests/testthat/test-ggplotly_methods.R
+++ b/tests/testthat/test-ggplotly_methods.R
@@ -1,0 +1,41 @@
+context('ggplot test')
+
+data("pbmc_small")
+
+df <- pbmc_small
+df$number <- rnorm(ncol(df))
+df$factor <- sample(gl(3, 1, ncol(df)))
+
+test_that("ggplot", {
+  # cell metadata
+  p <- ggplot(df, aes(factor, number)) 
+  expect_silent(show(p))
+  expect_s3_class(p, "ggplot")
+  # assay data
+  g <- sample(rownames(df), 1)
+  fd <- join_features(df, g, shape="wide")
+  p <- ggplot(fd, aes(factor, .data[[g]]))
+  expect_silent(show(p))
+  expect_s3_class(p, "ggplot")
+  # reduced dimensions
+  p <- ggplot(df, aes(PC_1, PC_2, col=factor))
+  expect_silent(show(p))
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("plotly", {
+  # cell metadata
+  p <- plot_ly(df, x=~factor, y=~number, type="violin") 
+  expect_silent(show(p))
+  expect_s3_class(p, "plotly")
+  # assay data
+  g <- sample(rownames(df), 1)
+  fd <- join_features(df, g, shape="wide")
+  p <- plot_ly(fd, x=~factor, y=g, type="violin") 
+  expect_silent(show(p))
+  expect_s3_class(p, "plotly")
+  # reduced dimensions
+  p <- plot_ly(fd, x=~PC_1, y=~PC_2, type="scatter", mode="markers") 
+  expect_silent(show(p))
+  expect_s3_class(p, "plotly")
+})

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -42,3 +42,36 @@ test_that("aggregate_cells() returns expected values", {
                                   pull(.cell)] |>
         sum())
 })
+
+test_that("get_abundance_sc_wide", {
+  pbmc_abundance_wide <-
+    pbmc_small |>
+    get_abundance_sc_wide()
+  pbmc_abundance_wide |> 
+    nrow() |>
+    expect_equal(80)
+  pbmc_abundance_wide |> 
+    ncol() |>
+    expect_equal(21)
+  pbmc_abundance_wide |> 
+    pull("S100A9") |>
+    sum() |>
+    expect_equal(175.2576, tolerance = 0.1)
+})
+
+test_that("get_abundance_sc_long", {
+  pbmc_abundance_long <-
+    pbmc_small |>
+    get_abundance_sc_long()
+  pbmc_abundance_long |> 
+    nrow() |>
+    expect_equal(1600)
+  pbmc_abundance_long |> 
+    ncol() |>
+    expect_equal(3)
+  pbmc_abundance_long |> 
+    filter(.feature == "S100A9") |>
+    pull(".abundance_RNA") |>
+    sum() |>
+    expect_equal(175.2576, tolerance = 0.1)
+})

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -44,34 +44,25 @@ test_that("aggregate_cells() returns expected values", {
 })
 
 test_that("get_abundance_sc_wide", {
-  pbmc_abundance_wide <-
-    pbmc_small |>
-    get_abundance_sc_wide()
-  pbmc_abundance_wide |> 
-    nrow() |>
-    expect_equal(80)
-  pbmc_abundance_wide |> 
-    ncol() |>
-    expect_equal(21)
-  pbmc_abundance_wide |> 
-    pull("S100A9") |>
-    sum() |>
-    expect_equal(175.2576, tolerance = 0.1)
+  expect_equal(
+    pbmc_small |> get_abundance_sc_wide() |> nrow(),
+    pbmc_small[[]] |> nrow()
+  )
+  expect_equal(
+    pbmc_small |> get_abundance_sc_wide() |> pull("S100A9") |> sum(),
+    pbmc_small |> FetchData("S100A9") |> sum(), 
+    tolerance = 0.1
+ )
 })
 
 test_that("get_abundance_sc_long", {
-  pbmc_abundance_long <-
-    pbmc_small |>
-    get_abundance_sc_long()
-  pbmc_abundance_long |> 
-    nrow() |>
-    expect_equal(1600)
-  pbmc_abundance_long |> 
-    ncol() |>
-    expect_equal(3)
-  pbmc_abundance_long |> 
-    filter(.feature == "S100A9") |>
-    pull(".abundance_RNA") |>
-    sum() |>
-    expect_equal(175.2576, tolerance = 0.1)
+  expect_equal(pbmc_small |> get_abundance_sc_long() |> ncol(), 3)
+  expect_equal(
+    pbmc_small |> get_abundance_sc_long() |> filter(.feature == "S100A9") |> pull(".abundance_RNA") |> sum(),
+    pbmc_small |> FetchData("S100A9") |> sum(),
+    tolerance = 0.1
+  )
 })
+
+
+

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -5,10 +5,10 @@ data("pbmc_small")
 test_that("join_features",{
 
 
-  pbmc_small %>% 
-    join_features("CD3D") %>% 
-    slice(1) %>%
-    pull(.abundance_RNA) %>%
+  pbmc_small |> 
+    join_features("CD3D") |> 
+    slice(1) |>
+    pull(.abundance_RNA) |>
     expect_equal(6.35, tolerance=0.1)
 
 

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -2,31 +2,24 @@ context('methods test')
 
 data("pbmc_small")
 
-test_that("join_features",{
-
-
+test_that("join_features", {
   pbmc_small |> 
     join_features("CD3D") |> 
     slice(1) |>
     pull(.abundance_RNA) |>
-    expect_equal(6.35, tolerance=0.1)
-
-
+    expect_equal(6.35, tolerance = 0.1)
 })
 
 test_that("aggregate_cells() returns expected values", {
-  
   # Create pseudo-bulk object for testing
   pbmc_pseudo_bulk <-
     pbmc_small |>
     aggregate_cells(c(groups, letter.idents), assays = "RNA")
-  
   # Check row length is unchanged
   pbmc_pseudo_bulk |>
     distinct(.feature) |> 
     nrow() |>
     expect_equal(pbmc_small |> nrow())
-  
   # Check column length is correctly modified
   pbmc_pseudo_bulk |> 
     distinct(.sample) |> 
@@ -37,15 +30,15 @@ test_that("aggregate_cells() returns expected values", {
                    unique() |>
                    nrow()
     )
-  
   # Spot check for correctly aggregated count value of ACAP1 gene
   pbmc_pseudo_bulk |> 
     filter(.feature == "ACAP1" & .sample == "g1___A") |> 
     select(RNA) |> 
     as.numeric() |> 
-    expect_equal(Assays(pbmc_small, "RNA")["ACAP1", pbmc_small |>
-                                               as_tibble() |>
-                                               filter(groups == "g1", letter.idents == "A") |>
-                                               pull(.cell)] |>
-                   sum())
+    expect_equal(
+      Assays(pbmc_small, "RNA")["ACAP1", pbmc_small |>
+                                  as_tibble() |>
+                                  filter(groups == "g1", letter.idents == "A") |>
+                                  pull(.cell)] |>
+        sum())
 })

--- a/tests/testthat/test-pillar.R
+++ b/tests/testthat/test-pillar.R
@@ -1,0 +1,27 @@
+context('pillar test')
+
+test_string <- "A small string to test the function of pillar utilities."
+
+test_that("pillar___format_comment", {
+
+  test_string |>
+    pillar___format_comment(width = 20) |>
+    stringr::str_count("# ") |> 
+    expect_equal(5)
+})
+
+test_that("pillar___strwrap2", {
+  
+  test_string |>
+    pillar___strwrap2(width = 20, indent = 4) |>
+    stringr::str_count("      ") |> 
+    expect_equal(c(0, 1, 1, 1, 1))
+})
+
+test_that("pillar___wrap", {
+    
+  test_string |>
+    pillar___wrap(width = 20) |>
+    stringr::str_count("\n") |> 
+    expect_equal(3)
+})

--- a/tests/testthat/test-pillar.R
+++ b/tests/testthat/test-pillar.R
@@ -3,7 +3,6 @@ context('pillar test')
 test_string <- "A small string to test the function of pillar utilities."
 
 test_that("pillar___format_comment", {
-
   test_string |>
     pillar___format_comment(width = 20) |>
     stringr::str_count("# ") |> 
@@ -11,7 +10,6 @@ test_that("pillar___format_comment", {
 })
 
 test_that("pillar___strwrap2", {
-  
   test_string |>
     pillar___strwrap2(width = 20, indent = 4) |>
     stringr::str_count("      ") |> 
@@ -19,7 +17,6 @@ test_that("pillar___strwrap2", {
 })
 
 test_that("pillar___wrap", {
-    
   test_string |>
     pillar___wrap(width = 20) |>
     stringr::str_count("\n") |> 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,0 +1,17 @@
+context('print test')
+
+data("pbmc_small")
+
+test_that("print", {
+  text <- capture.output(print(pbmc_small))
+  expect_equal(grep("Seurat-tibble abstraction", text), 1)
+  i <- grep(str <- ".*Features=([0-9]+).*", text)
+  expect_equal(gsub(str, "\\1", text[i]), paste(nrow(pbmc_small)))
+  i <- grep(str <- ".*Cells=([0-9]+).*", text)
+  expect_equal(gsub(str, "\\1", text[i]), paste(ncol(pbmc_small)))
+})
+
+test_that("glimpse", {
+  text <- capture.output(glimpse(pbmc_small))
+  expect_equal(length(text), 37)
+})

--- a/tests/testthat/test-tidyr.R
+++ b/tests/testthat/test-tidyr.R
@@ -1,76 +1,52 @@
 context('tidyr test')
 
 data("pbmc_small")
-tt = GetAssayData(pbmc_small, slot = 'counts', assay = "RNA") |> CreateSeuratObject() |> mutate(groups = sprintf("g%s", rep(1:2, dplyr::n()/2)))
+tt <- GetAssayData(pbmc_small, slot = 'counts', assay = "RNA") |> CreateSeuratObject() |> mutate(groups = sprintf("g%s", rep(1:2, dplyr::n()/2)))
 
-test_that("nest_unnest",{
-
-  col_names = colnames(tt[[]]) |> c("cell")
-
-  x =     tt |> nest(data = -groups) |> unnest(data) |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
-  y =     tt |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
-
-
+test_that("nest_unnest", {
+  col_names <- colnames(tt[[]]) |> c("cell")
+  x <- tt |> nest(data = -groups) |> unnest(data) |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
+  y <- tt |> Seurat::ScaleData() |> Seurat::FindVariableFeatures() |> Seurat::RunPCA()
   expect_equal(
     x[["pca"]]@cell.embeddings |> as_tibble(rownames = "cell") |> arrange(cell) |> pull(PC_1),
     y[["pca"]]@cell.embeddings |> as_tibble(rownames = "cell") |> arrange(cell) |> pull(PC_1)
   )
-
-
 })
 
-
-test_that("fast_vs_slow_nest",{
-  
+test_that("fast_vs_slow_nest", {
   expect_identical(
     tt |> mutate(groups2 = groups) |> nest(data = -c(groups, groups2)) |> select(-groups2),
     tt |> nest(data = -groups) 
   )
-  
-  
 })
 
-test_that("nest_unnest_slice_1",{
-
+test_that("nest_unnest_slice_1", {
   tt |>
     nest(data = -groups) |>
     slice(1) |>
     unnest(data) |> 
     ncol() |>
     expect_equal(40)
-
 })
 
 
-test_that("unite separate",{
-
-  un = tt |> unite("new_col", c(orig.ident, groups))
-
-  expect_equal( un |> select(new_col) |> slice(1) |> pull(new_col),   "SeuratProject_g1")
-
-  se = un |> separate(col = new_col, into= c("orig.ident", "groups"))
-
-  expect_equal( se |> select(orig.ident) |> ncol(),   1)
-
-
+test_that("unite separate", {
+  un <- tt |> unite("new_col", c(orig.ident, groups))
+  se <- un |> separate(col = new_col, into = c("orig.ident", "groups"))
+  expect_equal(un |> select(new_col) |> slice(1) |> pull(new_col), "SeuratProject_g1")
+  expect_equal(se |> select(orig.ident) |> ncol(), 1)
 })
 
-test_that("extract",{
-
+test_that("extract", {
   expect_equal(
-    tt |> extract(groups, into = "g", regex = "g([0-9])", convert = TRUE) |> pull(g) |> class() ,
+    tt |> extract(groups, into = "g", regex = "g([0-9])", convert = TRUE) |> pull(g) |> class(),
     "integer"
   )
-
-
 })
 
-test_that("pivot_longer",{
-
+test_that("pivot_longer", {
   expect_equal(
     tt |> pivot_longer(c(orig.ident, groups), names_to = "name", values_to = "value")  |> class() |> magrittr::extract2(1),
     "tbl_df"
   )
-
-
 })

--- a/tests/testthat/test-tidyr.R
+++ b/tests/testthat/test-tidyr.R
@@ -21,15 +21,11 @@ test_that("fast_vs_slow_nest", {
 })
 
 test_that("nest_unnest_slice_1", {
-  tt |>
-    nest(data = -groups) |>
-    slice(1) |>
-    unnest(data) |> 
-    ncol() |>
-    expect_equal(40)
+  expect_equal(
+    tt |> nest(data = -groups) |> slice(1) |> unnest(data) |> ncol(),
+    sum(tt[[]]$groups == "g1")
+  )
 })
-
-
 test_that("unite separate", {
   un <- tt |> unite("new_col", c(orig.ident, groups))
   se <- un |> separate(col = new_col, into = c("orig.ident", "groups"))

--- a/tests/testthat/test-tidyr.R
+++ b/tests/testthat/test-tidyr.R
@@ -35,7 +35,9 @@ test_that("nest_unnest_slice_1",{
   tt |>
     nest(data = -groups) |>
     slice(1) |>
-    unnest(data)
+    unnest(data) |> 
+    ncol() |>
+    expect_equal(40)
 
 })
 

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1,0 +1,44 @@
+context('utilities test')
+
+data("pbmc_small")
+
+test_that("get_abundance_sc_wide", {
+  
+  pbmc_abundance_wide <-
+    pbmc_small |>
+    get_abundance_sc_wide()
+
+  pbmc_abundance_wide |> 
+    nrow() |>
+    expect_equal(80)
+  
+  pbmc_abundance_wide |> 
+    ncol() |>
+    expect_equal(21)
+  
+  pbmc_abundance_wide |> 
+    pull("S100A9") |>
+    sum() |>
+    expect_equal(175.2576, tolerance = 0.1)
+})
+
+test_that("get_abundance_sc_long", {
+
+  pbmc_abundance_long <-
+    pbmc_small |>
+    get_abundance_sc_long()
+  
+  pbmc_abundance_long |> 
+    nrow() |>
+    expect_equal(1600)
+  
+  pbmc_abundance_long |> 
+    ncol() |>
+    expect_equal(3)
+  
+  pbmc_abundance_long |> 
+    filter(.feature == "S100A9") |>
+    pull(".abundance_RNA") |>
+    sum() |>
+    expect_equal(175.2576, tolerance = 0.1)
+})

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -34,3 +34,17 @@ test_that("get_abundance_sc_long", {
     sum() |>
     expect_equal(175.2576, tolerance = 0.1)
 })
+
+test_that("get_special_column_name_symbol", {
+  expect_equal(get_special_column_name_symbol(".cell")$symbol, rlang::sym(".cell"))
+  expect_equal(get_special_column_name_symbol(".cell")$name, c(".cell"))
+})
+
+test_that("ping_old_special_column_into_metadata", {
+  ping_old_special_column_into_metadata(pbmc_small) |>
+    as_tibble() |>
+    colnames() |>
+    purrr::pluck(1) |>
+    expect_equal("cell")
+})
+

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -2,39 +2,6 @@ context('utilities test')
 
 data("pbmc_small")
 
-test_that("get_abundance_sc_wide", {
-  pbmc_abundance_wide <-
-    pbmc_small |>
-    get_abundance_sc_wide()
-  pbmc_abundance_wide |> 
-    nrow() |>
-    expect_equal(80)
-  pbmc_abundance_wide |> 
-    ncol() |>
-    expect_equal(21)
-  pbmc_abundance_wide |> 
-    pull("S100A9") |>
-    sum() |>
-    expect_equal(175.2576, tolerance = 0.1)
-})
-
-test_that("get_abundance_sc_long", {
-  pbmc_abundance_long <-
-    pbmc_small |>
-    get_abundance_sc_long()
-  pbmc_abundance_long |> 
-    nrow() |>
-    expect_equal(1600)
-  pbmc_abundance_long |> 
-    ncol() |>
-    expect_equal(3)
-  pbmc_abundance_long |> 
-    filter(.feature == "S100A9") |>
-    pull(".abundance_RNA") |>
-    sum() |>
-    expect_equal(175.2576, tolerance = 0.1)
-})
-
 test_that("get_special_column_name_symbol", {
   expect_equal(get_special_column_name_symbol(".cell")$symbol, rlang::sym(".cell"))
   expect_equal(get_special_column_name_symbol(".cell")$name, c(".cell"))

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -3,19 +3,15 @@ context('utilities test')
 data("pbmc_small")
 
 test_that("get_abundance_sc_wide", {
-  
   pbmc_abundance_wide <-
     pbmc_small |>
     get_abundance_sc_wide()
-
   pbmc_abundance_wide |> 
     nrow() |>
     expect_equal(80)
-  
   pbmc_abundance_wide |> 
     ncol() |>
     expect_equal(21)
-  
   pbmc_abundance_wide |> 
     pull("S100A9") |>
     sum() |>
@@ -23,19 +19,15 @@ test_that("get_abundance_sc_wide", {
 })
 
 test_that("get_abundance_sc_long", {
-
   pbmc_abundance_long <-
     pbmc_small |>
     get_abundance_sc_long()
-  
   pbmc_abundance_long |> 
     nrow() |>
     expect_equal(1600)
-  
   pbmc_abundance_long |> 
     ncol() |>
     expect_equal(3)
-  
   pbmc_abundance_long |> 
     filter(.feature == "S100A9") |>
     pull(".abundance_RNA") |>


### PR DESCRIPTION
I created additional unit tests for the dplyr, tidyr and pillar adapters, and the `get_abundance` utilities. 

This brings tidyseurat test coverage to 78.64%, as calculated by dev_tools::test_coverage(). This still seems a bit low, but the remaining untested code does not seem amenable to testing. For example, plotting functions.