### PR TITLE
Allow to select a slot (e.g. scaled, raw etc..) in join_features()

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -68,9 +68,11 @@ setMethod(
 #' @param .data A Seurat object
 #' @param features A vector of feature identifiers to join
 #' @param all If TRUE return all
-#' @param exclude_zeros If TRUE exclude zero values
+#' @param exclude_zeros If TRUE exclude zero values in long format
 #' @param shape Format of the returned table "long" or "wide"
-#' @param ... Parameters to pass to join wide, i.e. assay name to extract feature abundance from and gene prefix, for shape="wide"
+#' @param assay assay name to extract feature abundance
+#' @param slot slot in the assay to extract feature abundance
+#' @param ... the other arguments
 #'
 #' @details This function extracts information for specified features and returns the information in either long or wide format.
 #'
@@ -81,7 +83,6 @@ setMethod(
 #' data("pbmc_small")
 #' pbmc_small %>% 
 #' join_features(features = c("HLA-DRA", "LYZ"))
-#'
 #'
 #' @export
 #'
@@ -98,7 +99,9 @@ setMethod("join_features", "Seurat",  function(.data,
                                                features = NULL,
                                                all = FALSE,
                                                exclude_zeros = FALSE,
-                                               shape = "long", ...)
+                                               shape = "long",
+                                               assay = .data@active.assay, 
+                                               slot = "data", ...)
 {
   .data %>%
     
@@ -111,7 +114,9 @@ setMethod("join_features", "Seurat",  function(.data,
           .data = .data,
           features = features,
           all = all,
-          exclude_zeros = exclude_zeros
+          exclude_zeros = exclude_zeros,
+          assay = assay,
+          slot = slot, ...
         ),
         by = c_(.data)$name
       ) %>%
@@ -122,7 +127,9 @@ setMethod("join_features", "Seurat",  function(.data,
         get_abundance_sc_wide(
           .data = .data,
           features = features,
-          all = all, ...
+          all = all,
+          assay = assay,
+          slot = slot, ...
         ),
         by = c_(.data)$name
       ) 

--- a/R/methods.R
+++ b/R/methods.R
@@ -100,7 +100,7 @@ setMethod("join_features", "Seurat",  function(.data,
                                                all = FALSE,
                                                exclude_zeros = FALSE,
                                                shape = "long",
-                                               assay = .data@active.assay, 
+                                               assay = NULL, 
                                                slot = "data", ...)
 {
   .data %>%
@@ -115,6 +115,7 @@ setMethod("join_features", "Seurat",  function(.data,
           features = features,
           all = all,
           exclude_zeros = exclude_zeros,
+          assay = assay,
           slot = slot, ...
         ),
         by = c_(.data)$name

--- a/R/methods.R
+++ b/R/methods.R
@@ -115,7 +115,6 @@ setMethod("join_features", "Seurat",  function(.data,
           features = features,
           all = all,
           exclude_zeros = exclude_zeros,
-          assay = assay,
           slot = slot, ...
         ),
         by = c_(.data)$name

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -156,13 +156,12 @@ get_abundance_sc_wide = function(.data, features = NULL, all = FALSE, assay = .d
 #' @param features A character
 #' @param all A boolean
 #' @param exclude_zeros A boolean
-#' @param assay assay name to extract feature abundance
 #' @param slot slot in the assay, e.g. `data` and `scale.data`
 #'
 #' @return A Seurat object
 #'
 #' @export
-get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_zeros = FALSE, assay = .data@active.assay, slot = "data"){
+get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_zeros = FALSE, slot = "data"){
 
   # Solve CRAN warnings
   . = NULL
@@ -192,11 +191,6 @@ get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_ze
   # Else
   else variable_genes = NULL
   
-  DefaultAssay(.data) = assay
-  for(i in Assays(.data) %>% setdiff(assay)) {
-    .data[[i]] = NULL
-  }
-
   assay_names = Assays(.data)
 
   .data@assays %>%

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -76,7 +76,7 @@ drop_class = function(var, name) {
 #' @param features A character
 #' @param all A boolean
 #' @param assay assay name to extract feature abundance
-#' @param slot slot in the assay e.g., `data` and `scale.data`
+#' @param slot slot in the assay, e.g. `data` and `scale.data`
 #' @param prefix prefix for the feature names
 #'
 #' @return A Seurat object
@@ -157,7 +157,7 @@ get_abundance_sc_wide = function(.data, features = NULL, all = FALSE, assay = .d
 #' @param all A boolean
 #' @param exclude_zeros A boolean
 #' @param assay assay name to extract feature abundance
-#' @param slot slot in the assay e.g. `data` and `scale.data`
+#' @param slot slot in the assay, e.g. `data` and `scale.data`
 #'
 #' @return A Seurat object
 #'

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -88,6 +88,10 @@ get_abundance_sc_wide = function(.data, features = NULL, all = FALSE, assay = .d
   . = NULL
   assays = NULL
   counts = NULL
+  
+  if (is.null(assay)) {
+  	assay <- .data@active.assay
+  }
 
   # Check if output would be too big without forcing
   if(
@@ -156,16 +160,21 @@ get_abundance_sc_wide = function(.data, features = NULL, all = FALSE, assay = .d
 #' @param features A character
 #' @param all A boolean
 #' @param exclude_zeros A boolean
+#' @param assay assay name to extract feature abundance
 #' @param slot slot in the assay, e.g. `data` and `scale.data`
 #'
 #' @return A Seurat object
 #'
 #' @export
-get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_zeros = FALSE, slot = "data"){
+get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_zeros = FALSE, assay=Assays(.data), slot = "data"){
 
   # Solve CRAN warnings
   . = NULL
-
+  
+  if (is.null(assay)) {
+  	assay <- Assays(.data)
+  }
+  
   # Check if output would be too big without forcing
   if(
     length(VariableFeatures(.data)) == 0  &
@@ -190,13 +199,10 @@ get_abundance_sc_long = function(.data, features = NULL, all = FALSE, exclude_ze
 
   # Else
   else variable_genes = NULL
-  
-  assay_names = Assays(.data)
-
   .data@assays %>%
-
+  	.[assay] %>%
     # Take active assay
-    map2(assay_names,
+    map2(assay,
          ~ .x %>%
            GetAssayData(slot) %>%
            when(

--- a/man/get_abundance_sc_long.Rd
+++ b/man/get_abundance_sc_long.Rd
@@ -9,7 +9,6 @@ get_abundance_sc_long(
   features = NULL,
   all = FALSE,
   exclude_zeros = FALSE,
-  assay = .data@active.assay,
   slot = "data"
 )
 }
@@ -21,8 +20,6 @@ get_abundance_sc_long(
 \item{all}{A boolean}
 
 \item{exclude_zeros}{A boolean}
-
-\item{assay}{assay name to extract feature abundance}
 
 \item{slot}{slot in the assay, e.g. `data` and `scale.data`}
 }

--- a/man/get_abundance_sc_long.Rd
+++ b/man/get_abundance_sc_long.Rd
@@ -9,6 +9,7 @@ get_abundance_sc_long(
   features = NULL,
   all = FALSE,
   exclude_zeros = FALSE,
+  assay = Assays(.data),
   slot = "data"
 )
 }
@@ -20,6 +21,8 @@ get_abundance_sc_long(
 \item{all}{A boolean}
 
 \item{exclude_zeros}{A boolean}
+
+\item{assay}{assay name to extract feature abundance}
 
 \item{slot}{slot in the assay, e.g. `data` and `scale.data`}
 }

--- a/man/get_abundance_sc_long.Rd
+++ b/man/get_abundance_sc_long.Rd
@@ -8,7 +8,9 @@ get_abundance_sc_long(
   .data,
   features = NULL,
   all = FALSE,
-  exclude_zeros = FALSE
+  exclude_zeros = FALSE,
+  assay = .data@active.assay,
+  slot = "data"
 )
 }
 \arguments{
@@ -19,6 +21,10 @@ get_abundance_sc_long(
 \item{all}{A boolean}
 
 \item{exclude_zeros}{A boolean}
+
+\item{assay}{assay name to extract feature abundance}
+
+\item{slot}{slot in the assay e.g. `data` and `scale.data`}
 }
 \value{
 A Seurat object

--- a/man/get_abundance_sc_long.Rd
+++ b/man/get_abundance_sc_long.Rd
@@ -24,7 +24,7 @@ get_abundance_sc_long(
 
 \item{assay}{assay name to extract feature abundance}
 
-\item{slot}{slot in the assay e.g. `data` and `scale.data`}
+\item{slot}{slot in the assay, e.g. `data` and `scale.data`}
 }
 \value{
 A Seurat object

--- a/man/get_abundance_sc_wide.Rd
+++ b/man/get_abundance_sc_wide.Rd
@@ -20,7 +20,11 @@ get_abundance_sc_wide(
 
 \item{all}{A boolean}
 
-\item{...}{Parameters to pass to join wide, i.e. assay name to extract feature abundance from}
+\item{assay}{assay name to extract feature abundance}
+
+\item{slot}{slot in the assay e.g., `data` and `scale.data`}
+
+\item{prefix}{prefix for the feature names}
 }
 \value{
 A Seurat object

--- a/man/get_abundance_sc_wide.Rd
+++ b/man/get_abundance_sc_wide.Rd
@@ -22,7 +22,7 @@ get_abundance_sc_wide(
 
 \item{assay}{assay name to extract feature abundance}
 
-\item{slot}{slot in the assay e.g., `data` and `scale.data`}
+\item{slot}{slot in the assay, e.g. `data` and `scale.data`}
 
 \item{prefix}{prefix for the feature names}
 }

--- a/man/join_features.Rd
+++ b/man/join_features.Rd
@@ -12,7 +12,7 @@
   all = FALSE,
   exclude_zeros = FALSE,
   shape = "long",
-  assay = .data@active.assay,
+  assay = NULL,
   slot = "data",
   ...
 )

--- a/man/join_features.Rd
+++ b/man/join_features.Rd
@@ -12,6 +12,8 @@
   all = FALSE,
   exclude_zeros = FALSE,
   shape = "long",
+  assay = .data@active.assay,
+  slot = "data",
   ...
 )
 }
@@ -22,11 +24,15 @@
 
 \item{all}{If TRUE return all}
 
-\item{exclude_zeros}{If TRUE exclude zero values}
+\item{exclude_zeros}{If TRUE exclude zero values in long format}
 
 \item{shape}{Format of the returned table "long" or "wide"}
 
-\item{...}{Parameters to pass to join wide, i.e. assay name to extract feature abundance from and gene prefix, for shape="wide"}
+\item{assay}{assay name to extract feature abundance}
+
+\item{slot}{slot in the assay to extract feature abundance}
+
+\item{...}{the other arguments}
 }
 \value{
 An object containing the information.for the specified features
@@ -44,6 +50,5 @@ This function extracts information for specified features and returns the inform
 data("pbmc_small")
 pbmc_small \%>\% 
 join_features(features = c("HLA-DRA", "LYZ"))
-
 
 }

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -2,11 +2,19 @@ context('methods test')
 
 data("pbmc_small")
 
-test_that("join_features", {
+test_that("join_features_long", {
   pbmc_small |> 
-    join_features("CD3D") |> 
+    join_features("CD3D", shape="long") |> 
     slice(1) |>
     pull(.abundance_RNA) |>
+    expect_equal(6.35, tolerance = 0.1)
+})
+
+test_that("join_features_wide", {
+  pbmc_small |> 
+    join_features("CD3D", shape="wide") |> 
+    slice(1) |>
+    pull(CD3D) |>
     expect_equal(6.35, tolerance = 0.1)
 })
 


### PR DESCRIPTION
@stemangiola 

I have made the following changes to `join_features()` and checked that `R CMD CHECK` does not produce any warnings or errors. I would be grateful if you could review the PR.

- add params for `assay` `slot` and `prefix` in `get_abundance_sc_wide()`
- make `get_abundance_sc_long()` handle `assay` and `slot` specification
- add arguments and params for `assay` `slot` in `get_abundance_sc_long()`
- add params for `assay` `slot` and `...` in `join_features()`