### PR TITLE
Update `slice_sample` in `dplyr_methods.R`

### DIFF
--- a/R/dplyr_methods.R
+++ b/R/dplyr_methods.R
@@ -593,9 +593,10 @@ slice_sample.Seurat <- function(.data, ..., n=NULL,
     count_cells <- new_meta %>%
         select(!!c_(.data)$symbol) %>%
         count(!!c_(.data)$symbol)
+    .max_cell_count <- ifelse(nrow(count_cells)==0, 0, max(count_cells$n))
 
     # If repeated cells due to replacement
-    if (count_cells$n |> max() |> gt(1)){
+    if (.max_cell_count |> gt(1)){
         message("tidyseurat says: When sampling with replacement",
             " a data frame is returned for independent data analysis.")
         .data |>

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -105,10 +105,13 @@ test_that("sample_n", {
 })
 
 test_that("slice_sample", {
-  pbmc_small |>
-    slice_sample(n = 50) |>
-    ncol() |>
-    expect_equal(50)
+    pbmc_small |>
+        slice_sample(n=50) |>
+        ncol() |>
+        expect_equal(50)
+    pbmc_small |>
+        slice_sample(n=0) |>
+        expect_error()
 })
 
 test_that("slice_head", {

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -110,8 +110,9 @@ test_that("slice_sample", {
         ncol() |>
         expect_equal(50)
     pbmc_small |>
-        slice_sample(n=0) |>
-        expect_error()
+      slice_sample(n=0) |>
+      expect_error() |>
+      expect_no_warning()
 })
 
 test_that("slice_head", {


### PR DESCRIPTION
Hello, this PR clears the warning in `slice_sample`. I would be grateful if you could review the code.
Related to: https://github.com/stemangiola/tidySingleCellExperiment/pull/90

```
> data(pbmc_small)
> pbmc_small |> slice_sample(n=0)
Error: No cells found
```